### PR TITLE
Updated for Vaadin 7.4.0

### DIFF
--- a/jslider-root/jslider/pom.xml
+++ b/jslider-root/jslider/pom.xml
@@ -4,12 +4,12 @@
 	<groupId>com.apeters.vaadin.addon.jslider</groupId>
 	<artifactId>jslider</artifactId>
 	<packaging>jar</packaging>
-	<version>1.2</version>
+	<version>1.3</version>
 	<name>JSlider Add-on</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>7.1.1</vaadin.version>
+		<vaadin.version>7.4.0</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 
 		<!-- ZIP Manifest fields -->

--- a/jslider-root/jslider/src/main/java/com/apeters/vaadin/addon/jslider/JSlider.java
+++ b/jslider-root/jslider/src/main/java/com/apeters/vaadin/addon/jslider/JSlider.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
-import org.json.JSONArray;
-import org.json.JSONException;
+import elemental.json.JsonArray;
+import elemental.json.JsonException;
 
 import com.apeters.vaadin.addon.jslider.client.JSliderState;
 import com.apeters.vaadin.addon.jslider.shared.Heterogeneity;
@@ -47,7 +47,7 @@ public class JSlider extends AbstractJavaScriptComponent {
 			private static final long serialVersionUID = -286554526404269688L;
 
 			@Override
-			public void call(JSONArray arguments) throws JSONException {
+			public void call(JsonArray arguments) throws JsonException {
 				setValue(arguments.getString(0));
 			}
 		});


### PR DESCRIPTION
Hi,
Vaadin made incompatible changes to the JavascriptFunction interface (using `elemental.json.*` instead of `org.json.*`) so I updated Vaadin version and JSlider version in pom.xml and changed the `org.json.*` references in JSlider.java to `elemental.json.*`.
See [Vaadin's announcement](http://vaadin.com/download/release/7.4/7.4.0/release-notes.html#incompatible).
Thank you in advance for reviewing these changes :)
Valentin
